### PR TITLE
Add secondary sort, sort by ship type, fixes

### DIFF
--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -90,6 +90,7 @@
 	  <dd class="order_id hover toggle active up" data-order="id">By ID</dd>
 	  <dd class="order_xpdiff hover toggle" data-order="xpdiff">By XP Left</dd>
 	  <dd class="order_name hover toggle" data-order="name">By Name</dd>
+	  <dd class="order_shiptype hover toggle" data-order="shiptype">By Ship Type</dd>
 	  <dd class="order_level hover toggle" data-order="level">By Level</dd>
 	  <dd class="order_remodel hover toggle" data-order="remodel">By Remodel</dd>
 	  <dd class="order_lvldiff hover toggle" data-order="lvldiff">By Levels To Remodel</dd>

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -73,7 +73,7 @@
 				showOtherShips: true,
                 shipsOrderType: "id",
                 shipsSortDirection: "up",
-                shipsOrderSecondType: "id",
+                shipsOrderSecondType: "",
                 shipsSortSecondDirection: "up",
 				closeToRemodelLevelDiff: 5
 			};
@@ -88,7 +88,7 @@
 					settings = JSON.parse( localStorage.srExpcalc );
 					settings.shipsOrderType = "id";
 					settings.shipsSortDirection = "up";
-					settings.shipsOrderSecondType = "id";
+					settings.shipsOrderSecondType = "";
 					settings.shipsSortSecondDirection = "up";
 				} else {
 					settings = JSON.parse( localStorage.srExpcalc );
@@ -170,7 +170,7 @@
 				updateUI();
 			});
             jqOrderTypes.on("click", function(e) {
-                if (e.shiftKey) {
+                if (e.shiftKey && self.getSettings().shipsOrderType != $(this).data("order")) {
 					if ($(this).hasClass("up")) {
 						self.modifySettings(updateOrder("shipsSortSecondDirection", "down"));
 					} else {
@@ -232,7 +232,7 @@
                         if (sortType == "id") {
                             return isUp * (+$(b).attr("id").substr(7) - +$(a).attr("id").substr(7));
                         } else if (sortType == "name") {
-                            return isUp * (($(b).find(".ship_info .ship_name").text().toUpperCase() > $(a).find(".ship_info .ship_name").text().toUpperCase()) ? 1 : -1);
+                            return isUp * ($(b).find(".ship_info .ship_name").text().toUpperCase().localeCompare($(a).find(".ship_info .ship_name").text().toUpperCase()));
                         } else if (sortType == "level") {
                             return isUp * (+$(b).find(".ship_lv .ship_value").text() - +$(a).find(".ship_lv .ship_value").text());
                         } else if (sortType == "remodel") {
@@ -242,7 +242,7 @@
                         } else if (sortType == "xpdiff") {
                             return isUp * (+$(b).find(".ship_exp .ship_value").text() - +$(a).find(".ship_exp .ship_value").text());
                         } else if (sortType == "shiptype") {
-                            return isUp * (($(b).find(".ship_info .ship_type").text() > $(a).find(".ship_info .ship_type").text()) ? 1 : -1);
+                            return isUp * ($(b).find(".ship_info .ship_type").text().localeCompare($(a).find(".ship_info .ship_type").text()));
                         }
                     };
                     sortedElements.sort(function(a, b) {

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -131,6 +131,7 @@
 					.toggleClass("active", settings.showOtherShips);
 
 				jqCloseToRemLvlDiff.val( settings.closeToRemodelLevelDiff );
+				orderShips(settings.shipsOrderType, settings.shipsSortDirection);
 			}
 
 			updateUI();
@@ -169,7 +170,6 @@
 					self.modifySettings(updateOrder("shipsSortDirection", "up"));
 				}
                 self.modifySettings(updateOrder("shipsOrderType", $(this).data("order")));
-                orderShips($(this).data("order"), ($(this).hasClass("up")) ? "down" : "up");
                 updateUI();
             });
 			jqCloseToRemLvlDiff
@@ -220,12 +220,7 @@
                         } else if (sortKey == "lvldiff") {
                             return isUp * ((+$(b).find(".ship_target .ship_value").text() - +$(b).find(".ship_lv .ship_value").text()) - (+$(a).find(".ship_target .ship_value").text() - +$(a).find(".ship_lv .ship_value").text()));
                         } else if (sortKey == "xpdiff") {
-                            // Doesn't take current progress through current level in account for non-active ships
-                            if (+$(b).find(".ship_exp .ship_value").text() === 0 || +$(a).find(".ship_exp .ship_value").text() === 0) {
-                                return isUp * ((KC3Meta.expShip(+$(b).find(".ship_target .ship_value").text())[1] - KC3Meta.expShip(+$(b).find(".ship_lv .ship_value").text())[1]) - (KC3Meta.expShip(+$(a).find(".ship_target .ship_value").text())[1] - KC3Meta.expShip(+$(a).find(".ship_lv .ship_value").text())[1]));
-							} else {
-                                return isUp * (+$(b).find(".ship_exp .ship_value").text() - +$(a).find(".ship_exp .ship_value").text());
-							}
+                            return isUp * (+$(b).find(".ship_exp .ship_value").text() - +$(a).find(".ship_exp .ship_value").text());
                         }
                     })
                     .prependTo(boxSorted);
@@ -305,8 +300,6 @@
 		---------------------------------*/
 		execute :function(){
 			var self = this;
-			self.configSectionToggles();
-			self.configHighlightToggles();
 
 			// Add map list into the factory drop-downs
 			$.each(this.maplist, function(MapName, MapExp){
@@ -702,6 +695,8 @@
 					return true;
 
 				$(".ship_target .ship_value", goalBox).text( goalLevel );
+				var expLeft = KC3Meta.expShip(goalLevel)[1] - ThisShip.exp[0];
+				$(".ship_exp .ship_value", goalBox).text( expLeft );
 				if (goalLevel < 99) {
 					goalBox.appendTo(".section_expcalc .box_recommend");
 					return true;
@@ -714,6 +709,8 @@
 
 			//this.save();
 
+			self.configSectionToggles();
+			self.configHighlightToggles();
 			$("<div />").addClass("clear").appendTo(".section_expcalc .box_recommend");
 			$("<div />").addClass("clear").appendTo(".section_expcalc .box_other");
 		},

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -241,6 +241,8 @@
                             return isUp * ((+$(b).find(".ship_target .ship_value").text() - +$(b).find(".ship_lv .ship_value").text()) - (+$(a).find(".ship_target .ship_value").text() - +$(a).find(".ship_lv .ship_value").text()));
                         } else if (sortType == "xpdiff") {
                             return isUp * (+$(b).find(".ship_exp .ship_value").text() - +$(a).find(".ship_exp .ship_value").text());
+                        } else if (sortType == "shiptype") {
+                            return isUp * (($(b).find(".ship_info .ship_type").text() > $(a).find(".ship_info .ship_type").text()) ? 1 : -1);
                         }
                     };
                     sortedElements.sort(function(a, b) {


### PR DESCRIPTION
Fix settings not applying on load
Make exp sort also sort for inactive ships
Add secondary sort (hold shift to select second sorter)
Add sort by ship type